### PR TITLE
Remove hardcoded secrect

### DIFF
--- a/app/utils/authentication.py
+++ b/app/utils/authentication.py
@@ -18,10 +18,14 @@ import os  # Para acceder a variables de entorno.
 # Cargar variables del archivo .env
 load_dotenv()
 
+def get_required_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise Exception("Env var '"+name+"' is required but not found.")
+    return value
+
 # Clave secreta para firmar JWT
-SECRET_KEY = os.getenv(
-    "SECRET_KEY", "eaa10e914aaeb96f7494243535450597ed1bbd23502da94db4e236d0eea4a3d5"
-)
+SECRET_KEY = get_required_env("SECRET_KEY")
 
 # Algoritmo de encriptación JWT
 ALGORITHM = "HS256"


### PR DESCRIPTION
Esto es solo una propuesta, no he probado este cambio.

Según veo hay un valor por defecto del secreto para codificar los JWT hardcodeado en el proyecto. He probado a usar este secreto para crear un JWT y hacer llamadas a endpoints protegidos y parece no funcionar así que supongo que el valor del secreto es otro en el servicio desplegado.

Aun así creo que es un problema de seguridad dejar este valor tal como está. Pongamos el siguiente escenario: Se despliega el micro pero por error no se establece un valor para la variable de entorno `SECRET_KEY` o se declara mal (`SECRE_KEY`), en este caso el micro tomará el valor por defecto y levantará con normalidad, pero con un secreto distinto del esperado y además publicado lo que podría ser un problema de seguridad.

Los cambios propuestos deberían garantizar que el micro solo pueda arrancar si la variable de entorno `SECRET_KEY` ha sido definida y tiene un valor.